### PR TITLE
Upgrade `set-output` command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ jobs:
 ## Workflow
 
 * Add this action to your repo
-* Commit some changes with message contains `#major` or `#patch` or `#patch`
+* Commit some changes with message contains `#major` or `#minor` or `#patch`
 * Either push to master or open a PR
 * On push (or merge) to `master`, the action will:
   * Get latest tag
-  * Generate tag if commit message contains `#major` or `#patch` or `#patch`
+  * Generate tag if commit message contains `#major` or `#minor` or `#patch`
     > ***Note:*** This action **will not** push the tag if the `HEAD` commit has already been tagged. If two or more keywords are present, the highest-ranking one will take precedence.
   * Pushes tag to GitHub
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo ::set-output name=tag_generated::0
+echo tag_generated=0 >> $GITHUB_OUTPUT
 
 # config
 with_v=${WITH_V:-false}
@@ -32,16 +32,16 @@ echo $tag
 last_major=$(semver get major $tag)
 last_minor=$(semver get minor $tag)
 last_patch=$(semver get patch $tag)
-echo ::set-output name=last_major::$last_major
-echo ::set-output name=last_minor::$last_minor
-echo ::set-output name=last_patch::$last_patch
+echo last_major=$last_major >> $GITHUB_OUTPUT
+echo last_minor=$last_minor >> $GITHUB_OUTPUT
+echo last_patch=$last_patch >> $GITHUB_OUTPUT
 
 # get current commit hash for tag
 commit=$(git rev-parse HEAD)
 
 if [ "$tag_commit" == "$commit" ]; then
     echo "No new commits since previous tag. Skipping the tag creation..."
-    echo ::set-output name=last_tag::$tag
+    echo last_tag=$tag >> $GITHUB_OUTPUT
     exit 0
 fi
 
@@ -73,7 +73,7 @@ case "$log" in
         ;;
     * )
         echo "This commit message doesn't include #major, #minor or #patch. Skipping the tag creation..."
-        echo ::set-output name=last_tag::$tag
+        echo last_tag=$tag >> $GITHUB_OUTPUT
         exit 0
         ;;
 esac
@@ -84,12 +84,12 @@ then
 	# prefix with 'v'
 	if $with_v
 	then
-			new="v$new"
+		new="v$new"
 	fi
 
 	if $pre_release
 	then
-			new="$new-${commit:0:7}"
+		new="$new-${commit:0:7}"
 	fi
 fi
 
@@ -104,12 +104,12 @@ minor=$(semver get minor $new)
 patch=$(semver get patch $new)
 
 # set outputs
-echo ::set-output name=last_tag::$tag
-echo ::set-output name=new_tag::$new
-echo ::set-output name=major::$major
-echo ::set-output name=minor::$minor
-echo ::set-output name=patch::$patch
-echo ::set-output name=bump_ver::$bump_ver
+echo last_tag=$tag >> $GITHUB_OUTPUT
+echo new_tag=$new >> $GITHUB_OUTPUT
+echo major=$major >> $GITHUB_OUTPUT
+echo minor=$minor >> $GITHUB_OUTPUT
+echo patch=$patch >> $GITHUB_OUTPUT
+echo bump_ver=$bump_ver >> $GITHUB_OUTPUT
 
 if $pre_release
 then
@@ -133,4 +133,4 @@ curl -s -X POST $git_refs_url \
   "sha": "$commit"
 }
 EOF
-echo ::set-output name=tag_generated::1
+echo tag_generated=1 >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/